### PR TITLE
Correcting the number of nodes listed in system config

### DIFF
--- a/closed/Intel/systems/1-node-2S-SPR-PyTorch-INT8.json
+++ b/closed/Intel/systems/1-node-2S-SPR-PyTorch-INT8.json
@@ -5,7 +5,7 @@
     "system_type":"datacenter",
     "system_name": "1-node-2S-SPR-PyTorch-INT8",
 
-    "number_of_nodes": "2",
+    "number_of_nodes": "1",
     "host_processor_model_name": "Intel(R) Xeon(R) Platinum 8480+",
     "host_processors_per_node": "2",
     "host_processor_core_count": "56",

--- a/closed/Intel/systems/1-node-2S-SPR-PyTorch-MIX.json
+++ b/closed/Intel/systems/1-node-2S-SPR-PyTorch-MIX.json
@@ -5,7 +5,7 @@
     "system_type":"datacenter",
     "system_name": "1-node-2S-SPR-PyTorch-INT8",
 
-    "number_of_nodes": "2",
+    "number_of_nodes": "1",
     "host_processor_model_name": "Intel(R) Xeon(R) Platinum 8480+",
     "host_processors_per_node": "2",
     "host_processor_core_count": "56",

--- a/open/Intel/systems/1-node-2S-ICX-Neural_Engine-INT8.json
+++ b/open/Intel/systems/1-node-2S-ICX-Neural_Engine-INT8.json
@@ -5,7 +5,7 @@
     "system_type":"datacenter",
     "system_name": "1-node-2S-ICX-Neural_Engine-INT8",
 
-    "number_of_nodes": "2",
+    "number_of_nodes": "1",
     "host_processor_model_name": "Intel(R) Xeon(R) Platinum 8380",
     "host_processors_per_node": "2",
     "host_processor_core_count": "40",

--- a/open/Intel/systems/1-node-2S-SPR-Neural_Engine-INT8.json
+++ b/open/Intel/systems/1-node-2S-SPR-Neural_Engine-INT8.json
@@ -5,7 +5,7 @@
     "system_type":"datacenter",
     "system_name": "1-node-2S-SPR-Neural_Engine-INT8",
 
-    "number_of_nodes": "2",
+    "number_of_nodes": "1",
     "host_processor_model_name": "Intel(R) Xeon(R) Platinum 8480+",
     "host_processors_per_node": "2",
     "host_processor_core_count": "56",


### PR DESCRIPTION
All submitted workloads by Intel used 1 node.  Updating the system configs to reflect this.